### PR TITLE
Update shebang for wider support

### DIFF
--- a/rtfm.py
+++ b/rtfm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python2.7
 """# Allright I know it should be python3
 ##
 # Inspired by : https://xkcd.com/293/


### PR DESCRIPTION
```/usr/bin/env python``` allows for better universal support.

 eg. on Mac: ```/usr/bin/python2.7``` is a symlink to the builtin Python.framework. Homebrew installs python / pip to ```/usr/local/bin/python2.7```